### PR TITLE
enhance encryption according to http://cipherli.st

### DIFF
--- a/rutorrent-tls.nginx
+++ b/rutorrent-tls.nginx
@@ -23,9 +23,12 @@ server {
         keepalive_timeout   60;
         ssl_certificate      /etc/nginx/ssl/nginx.crt;
         ssl_certificate_key  /etc/nginx/ssl/nginx.key;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers  "RC4:HIGH:!aNULL:!MD5:!kEDH";
-        add_header Strict-Transport-Security 'max-age=604800';
+				ssl_ciphers "AES128+EECDH:AES128+EDH";
+				ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+				ssl_prefer_server_ciphers on;
+				ssl_session_cache shared:SSL:10m;
+				add_header X-Frame-Options DENY;
+				add_header X-Content-Type-Options nosniff;
 
 	root /var/www/rutorrent;
 	index index.php index.html index.htm;
@@ -45,7 +48,7 @@ server {
 
 	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
 	#location /RequestDenied {
-	#	proxy_pass http://127.0.0.1:8080;    
+	#	proxy_pass http://127.0.0.1:8080;
 	#}
 
 	#error_page 404 /404.html;
@@ -62,7 +65,7 @@ server {
 	location ~ \.php$ {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
 	# NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
-	
+
 		# With php5-cgi alone:
 	#	fastcgi_pass 127.0.0.1:9000;
 	#	# With php5-fpm:


### PR DESCRIPTION
Hello.
I've set the encryption ciphers according to http://cipherli.st . This should provide more robust encryption.
[here](https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html) is the rationale. I've disabled stapling since most users will use self-signed certificates.