### PR TITLE
Switching from unrar-free to unrar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD ./ffmpeg-next.list /etc/apt/sources.list.d/ffmpeg-next.list
 
 # install
 RUN apt-get update && \
-    apt-get install -y --force-yes rtorrent unzip unrar-free mediainfo curl php5-fpm php5-cli php5-geoip nginx wget ffmpeg supervisor && \
+    apt-get install -y --force-yes rtorrent unzip unrar mediainfo curl php5-fpm php5-cli php5-geoip nginx wget ffmpeg supervisor && \
     rm -rf /var/lib/apt/lists/*
 
 # configure nginx


### PR DESCRIPTION
```unrar-free``` doesn't work with the unpack plugin. This commit makes the container use ```unrar``` instead, which is what rutorrent is designed for.