### PR TITLE
fix JS error on nginx-tls: Blocked a frame with origin from accessing…

### DIFF
--- a/rutorrent-tls.nginx
+++ b/rutorrent-tls.nginx
@@ -27,7 +27,7 @@ server {
 				ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 				ssl_prefer_server_ciphers on;
 				ssl_session_cache shared:SSL:10m;
-				add_header X-Frame-Options DENY;
+				add_header X-Frame-Options SAMEORIGIN;
 				add_header X-Content-Type-Options nosniff;
 
 	root /var/www/rutorrent;


### PR DESCRIPTION
Posible fix for JS error on nginx-tls: <https://github.com/diameter/rtorrent-rutorrent/issues/7>