### PR TITLE
Fix Request Entity Too Large error

### DIFF
--- a/rutorrent-basic.nginx
+++ b/rutorrent-basic.nginx
@@ -26,6 +26,11 @@ server {
 
 	# Make site accessible from http://localhost/
 	server_name localhost;
+	
+	# Allow larger .torrent files to upload.
+	# If experiencing a "413 Request Entity Too Large" error,
+	# feel free to increase this setting. 
+	client_max_body_size 2M;
 
 	location / {
 		# First attempt to serve request as file, then


### PR DESCRIPTION
When uploading torrent files through the rutorrent interface, a Request Entity Too Large error occurs when the torrent file is larger than 1MB. This change resolves this by increasing the client_max_body_size setting in Nginx.